### PR TITLE
Quitar # innecesarias

### DIFF
--- a/Tema_2_Procesos_e_Hilos.md
+++ b/Tema_2_Procesos_e_Hilos.md
@@ -1,7 +1,7 @@
 
-# TEMA 2: PROCESOS E HILOS. #
-## REPASO ##
-##### PROCESO: #####
+# TEMA 2: PROCESOS E HILOS.
+## REPASO
+##### PROCESO:
 1. Programa en ejecución.
 2. Instancia de un programa ejecutado en un computador.
 3. La entidad que se puede asignar y ejecutar en un procesador.


### PR DESCRIPTION
Meter los titulos entre # es equivalente a ponerlas al principio y quita errores a la hora de compilar a pdf